### PR TITLE
fix: #1 incorrect youtube link and other suggestions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,7 +1,5 @@
 name: e2e tests
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - /usr/src/app/node_modules
     env_file:
       - .env
+    environment:
+      REDIS_URL: redis://redis:6379
     command: yarn e2e
     ports:
       - 3000:3000

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
   "dependencies": {
     "@solidjs/meta": "^0.28.2",
     "@solidjs/router": "^0.8.2",
+    "@types/string-similarity": "^4.0.0",
     "cheerio": "^1.0.0-rc.12",
     "ioredis": "^5.3.1",
     "solid-js": "^1.6.11",
     "solid-start": "^0.2.26",
+    "string-similarity": "^4.0.4",
     "undici": "^5.15.1"
   },
   "devDependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,8 +18,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
-
+    baseURL: 'http://127.0.0.1:3000',
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
   },
@@ -30,35 +29,13 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
-
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-
-    /* Test against mobile viewports. */
     // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
     // },
     // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ..devices['Desktop Chrome'], channel: 'chrome' },
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
     // },
   ],
 

--- a/src/@types/global.ts
+++ b/src/@types/global.ts
@@ -7,11 +7,16 @@ export enum SpotifyMetadataType {
   Show = 'website',
 }
 
-export enum SpotifyContentLink {
+export enum SpotifyContentLinkType {
   Youtube = 'youtube',
   AppleMusic = 'appleMusic',
   Tidal = 'tidal',
   SoundCloud = 'soundCloud',
+}
+
+export interface SpotifyContentLink {
+  type: SpotifyContentLinkType;
+  url: string;
 }
 
 export interface SpotifyContent {
@@ -22,10 +27,5 @@ export interface SpotifyContent {
   image: string;
   audio?: string;
   source: string;
-  links: {
-    [SpotifyContentLink.Youtube]: string;
-    [SpotifyContentLink.AppleMusic]: string;
-    [SpotifyContentLink.Tidal]: string;
-    [SpotifyContentLink.SoundCloud]: string;
-  };
+  links: SpotifyContentLink[];
 }

--- a/src/components/SearchCard.tsx
+++ b/src/components/SearchCard.tsx
@@ -1,6 +1,6 @@
-import { Component } from 'solid-js';
+import { Component, For } from 'solid-js';
 
-import type { SpotifyContent } from '~/@types/global';
+import { SpotifyContentLinkType, type SpotifyContent } from '~/@types/global';
 
 import AudioPreview from './AudioPreview';
 
@@ -8,26 +8,51 @@ interface SearchCardProps {
   spotifyContent: SpotifyContent;
 }
 
+const SPOTIFY_CONTENT_LINK_DICT = {
+  [SpotifyContentLinkType.Youtube]: {
+    icon: 'fab fa-youtube',
+    label: 'Listen on Youtube',
+    isRecommended: true,
+  },
+  [SpotifyContentLinkType.AppleMusic]: {
+    icon: 'fab fa-apple',
+    label: 'Listen on Apple Music',
+    isRecommended: false,
+  },
+  [SpotifyContentLinkType.Tidal]: {
+    icon: 'fa fa-music',
+    label: 'Listen on Tidal',
+    isRecommended: false,
+  },
+  [SpotifyContentLinkType.SoundCloud]: {
+    icon: 'fab fa-soundcloud',
+    label: 'Listen on SoundCloud',
+    isRecommended: false,
+  },
+};
+
 const SpotifyContentLink = (props: {
-  link: string,
-  icon: string,
-  label: string,
-  isRecommended?: boolean
-}) => (
-  <a
-    href={props.link}
-    target="_blank"
-    rel="noreferrer"
-    aria-label={props.label}
-    class="flex items-center hover:text-gray-300 text-sm sm:text-base"
-  >
-    <i class={`${props.icon} w-6 mr-1`} />
-    {props.label}
-    {props.isRecommended && (
-      <span class="inline-flex items-center ml-1 px-1 rounded-full text-[0.56rem] bg-green-500 text-black">Recommended</span>
-    )}
-  </a>
-);
+  type: SpotifyContentLinkType,
+  url: string,
+}) => {
+  const { label, icon, isRecommended } = SPOTIFY_CONTENT_LINK_DICT[props.type];
+
+  return (
+    <a
+      href={props.url}
+      target="_blank"
+      rel="noreferrer"
+      aria-label={label}
+      class="flex items-center hover:text-gray-300 text-sm sm:text-base"
+    >
+      <i class={`${icon} w-6 mr-1`} />
+      {label}
+      {isRecommended && (
+        <span class="inline-flex items-center ml-1 px-1 rounded-full text-[0.56rem] bg-green-500 text-black">Recommended</span>
+      )}
+    </a>
+  );
+};
 
 const SearchCard: Component<SearchCardProps> = (props) => (
   <div
@@ -39,34 +64,21 @@ const SearchCard: Component<SearchCardProps> = (props) => (
       image={props.spotifyContent.image}
       audio={props.spotifyContent.audio}
     />
-    <div class="flex flex-col items-start p-2">
+    <div class="flex flex-col items-start p-2 w-52 sm:w-2/3 truncate">
       <div class="font-bold text-xl">{props.spotifyContent.title}</div>
-      <p class="text-sm w-52 sm:w-96 truncate">{props.spotifyContent.description}</p>
-      <ul class="mt-2 text-base">
-        <li class="flex flex-col items-start">
-          <SpotifyContentLink
-            link={props.spotifyContent.links.youtube}
-            icon="fab fa-youtube"
-            label="Listen on Youtube"
-            isRecommended
-          />
-          <SpotifyContentLink
-            link={props.spotifyContent.links.appleMusic}
-            icon="fab fa-apple"
-            label="Listen on Apple Music"
-          />
-          <SpotifyContentLink
-            link={props.spotifyContent.links.tidal}
-            icon="fa fa-music"
-            label="Listen on Tidal"
-          />
-          <SpotifyContentLink
-            link={props.spotifyContent.links.soundCloud}
-            icon="fab fa-soundcloud"
-            label="Listen on SoundCloud"
-          />
-        </li>
-      </ul>
+      <p class="text-sm">{props.spotifyContent.description}</p>
+      {props.spotifyContent.links.length === 0 && (
+        <p class="my-12 text-sm text-center w-full">No links found</p>
+      )}
+      {props.spotifyContent.links.length > 0 && (
+        <ul class="mt-2 text-base">
+          <li class="flex flex-col items-start">
+            <For each={props.spotifyContent.links}>
+              {({ type, url }) => <SpotifyContentLink type={type} url={url} />}
+            </For>
+          </li>
+        </ul>
+      )}
     </div>
   </div>
 );

--- a/src/routes/api/search.ts
+++ b/src/routes/api/search.ts
@@ -1,5 +1,7 @@
 import { APIEvent, json } from 'solid-start/api';
 
+import { type SpotifyContent, SpotifyContentLinkType } from '~/@types/global';
+
 import { SPOTIFY_LINK_REGEX } from '~/constants';
 import { buildSpotifyContent } from '~/server/rpc/spotifyContent';
 
@@ -11,10 +13,27 @@ const apiError = (error: string, status: number): Response => new Response(
   },
 );
 
+function parseSpotifyContentV1(spotifyContent: SpotifyContent) {
+  const youtube = spotifyContent.links.find((link) => link.type === SpotifyContentLinkType.Youtube);
+  const appleMusic = spotifyContent.links.find((link) => link.type === SpotifyContentLinkType.AppleMusic);
+  const tidal = spotifyContent.links.find((link) => link.type === SpotifyContentLinkType.Tidal);
+  const soundcloud = spotifyContent.links.find((link) => link.type === SpotifyContentLinkType.SoundCloud);
+
+  return {
+    ...spotifyContent,
+    links: {
+      youtube: youtube?.url,
+      appleMusic: appleMusic?.url,
+      tidal: tidal?.url,
+      soundcloud: soundcloud?.url,
+    },
+  };
+}
+
 export async function GET({ request }: APIEvent) {
   const url = new URL(request.url);
 
-  const { spotifyLink } = Object.fromEntries(url.searchParams);
+  const { spotifyLink, v } = Object.fromEntries(url.searchParams);
 
   if (!SPOTIFY_LINK_REGEX.test(spotifyLink)) {
     return apiError('Invalid Spotify link', 400);
@@ -22,6 +41,11 @@ export async function GET({ request }: APIEvent) {
 
   try {
     const spotifyContent = await buildSpotifyContent(spotifyLink);
+
+    if (!v || v === '1') {
+      return json(parseSpotifyContentV1(spotifyContent));
+    }
+
     return json(spotifyContent);
   } catch (error) {
     return apiError((error as Error).message, 500);

--- a/src/server/rpc/spotifyContent.ts
+++ b/src/server/rpc/spotifyContent.ts
@@ -16,12 +16,18 @@ import { SPOTIFY_ID_REGEX } from '~/constants';
 export const buildSpotifyContent = server$(async (spotifyLink: string): Promise<SpotifyContent> => {
   const metadata = await getSpotifyMetadata(spotifyLink);
 
-  const id = spotifyLink.match(SPOTIFY_ID_REGEX)?.[0]!;
+  const id = (spotifyLink.match(SPOTIFY_ID_REGEX) ?? [])[0]!;
+
+  const links = [];
 
   const youtubeLink = await getYoutubeLink(metadata);
   const appleMusicLink = getAppleMusicLink(metadata);
   const tidalLink = getTidalLink(metadata);
   const soundcloudLink = getSoundCloudLink(metadata);
+
+  if (youtubeLink) {
+    links.push(youtubeLink, appleMusicLink, tidalLink, soundcloudLink);
+  }
 
   const spotifyContent: SpotifyContent = {
     id,
@@ -31,12 +37,7 @@ export const buildSpotifyContent = server$(async (spotifyLink: string): Promise<
     image: metadata.image,
     audio: metadata.audio,
     source: spotifyLink,
-    links: {
-      youtube: youtubeLink,
-      appleMusic: appleMusicLink,
-      tidal: tidalLink,
-      soundCloud: soundcloudLink,
-    },
+    links,
   };
 
   await Promise.all([

--- a/src/server/services/appleMusic.ts
+++ b/src/server/services/appleMusic.ts
@@ -1,3 +1,5 @@
+import { SpotifyContentLink, SpotifyContentLinkType } from '~/@types/global';
+
 import { SpotifyMetadata } from '~/server/services/spotify';
 import { getQueryFromMetadata } from '~/utils/query';
 
@@ -5,7 +7,7 @@ import * as ENV from '~/config/env/server';
 
 export const getAppleMusicLink = (metadata: SpotifyMetadata) => {
   const query = getQueryFromMetadata(metadata);
-  const url = `${ENV.services.appleMusic.baseUrl}${query}`;
+  const url = `${ENV.services.appleMusic.baseUrl}${encodeURIComponent(query)}`;
 
-  return url;
+  return { type: SpotifyContentLinkType.AppleMusic, url } as SpotifyContentLink;
 };

--- a/src/server/services/cache.ts
+++ b/src/server/services/cache.ts
@@ -7,7 +7,11 @@ import { cacheKey } from '~/config/redis';
 export const getSpotifyContentFromCache = async (id: string) => {
   const cache = await getKey(`${cacheKey}${id}`);
 
-  return cache ? JSON.parse(cache) : undefined;
+  if (!cache) {
+    return undefined;
+  }
+
+  return JSON.parse(cache) as SpotifyContent;
 };
 
 export const cacheSpotifyContent = async (spotifyContent: SpotifyContent) => {

--- a/src/server/services/soundcloud.ts
+++ b/src/server/services/soundcloud.ts
@@ -1,3 +1,5 @@
+import { SpotifyContentLink, SpotifyContentLinkType } from '~/@types/global';
+
 import { SpotifyMetadata } from '~/server/services/spotify';
 import { getQueryFromMetadata } from '~/utils/query';
 
@@ -5,7 +7,7 @@ import * as ENV from '~/config/env/server';
 
 export const getSoundCloudLink = (metadata: SpotifyMetadata) => {
   const query = getQueryFromMetadata(metadata);
-  const url = `${ENV.services.soundCloud.baseUrl}${query}`;
+  const url = `${ENV.services.soundCloud.baseUrl}${encodeURIComponent(query)}`;
 
-  return url;
+  return { type: SpotifyContentLinkType.SoundCloud, url } as SpotifyContentLink;
 };

--- a/src/server/services/spotify.ts
+++ b/src/server/services/spotify.ts
@@ -1,6 +1,6 @@
-import * as cheerio from 'cheerio';
-
 import { SpotifyMetadataType } from '~/@types/global';
+
+import { getCheerioDoc, metaTagContent } from '~/utils/metaContent';
 
 export interface SpotifyMetadata {
   title: string;
@@ -10,20 +10,16 @@ export interface SpotifyMetadata {
   audio?: string;
 }
 
-function metaTagContent(doc: cheerio.CheerioAPI, type: string, attr: string) {
-  return doc(`meta[${attr}='${type}']`).attr('content');
-}
-
 export const getSpotifyMetadata = async (spotifyLink: string): Promise<SpotifyMetadata> => {
   const html = await fetch(spotifyLink).then((res) => res.text());
-  const doc = cheerio.load(html);
+  const doc = getCheerioDoc(html);
 
   const title = metaTagContent(doc, 'og:title', 'property');
   const description = metaTagContent(doc, 'og:description', 'property');
   const image = metaTagContent(doc, 'og:image', 'property');
   const audio = metaTagContent(doc, 'og:audio', 'property');
 
-  const type = spotifyLink.includes('episode') ? SpotifyMetadataType.Podcast : metaTagContent(doc, 'og:type', 'property') as SpotifyMetadataType;
+  const type = spotifyLink.includes('episode') ? SpotifyMetadataType.Podcast : metaTagContent(doc, 'og:type', 'property');
 
   if (!title || !description || !type || !image) {
     throw new Error('Could not parse Spotify metadata');
@@ -32,7 +28,7 @@ export const getSpotifyMetadata = async (spotifyLink: string): Promise<SpotifyMe
   return {
     title,
     description,
-    type,
+    type: type as SpotifyMetadataType,
     image,
     audio,
   };

--- a/src/server/services/tidal.ts
+++ b/src/server/services/tidal.ts
@@ -1,3 +1,5 @@
+import { SpotifyContentLink, SpotifyContentLinkType } from '~/@types/global';
+
 import { SpotifyMetadata } from '~/server/services/spotify';
 import { getQueryFromMetadata } from '~/utils/query';
 
@@ -5,7 +7,7 @@ import * as ENV from '~/config/env/server';
 
 export const getTidalLink = (metadata: SpotifyMetadata) => {
   const query = getQueryFromMetadata(metadata);
-  const url = `${ENV.services.tidal.baseUrl}${query}`;
+  const url = `${ENV.services.tidal.baseUrl}${encodeURIComponent(query)}`;
 
-  return url;
+  return { type: SpotifyContentLinkType.Tidal, url } as SpotifyContentLink;
 };

--- a/src/server/services/youtube.ts
+++ b/src/server/services/youtube.ts
@@ -56,7 +56,7 @@ export const getYoutubeLink = async (metadata: SpotifyMetadata) => {
 
   const youtubeVideoTitle = metaTagContent(doc, 'og:title', 'property') ?? '';
 
-  if (compareTwoStrings(youtubeVideoTitle, query) < 0.4) {
+  if (compareTwoStrings(youtubeVideoTitle, query) < 0.5) {
     return undefined;
   }
 

--- a/src/server/services/youtube.ts
+++ b/src/server/services/youtube.ts
@@ -1,7 +1,12 @@
+import { compareTwoStrings } from 'string-similarity';
+
+import { SpotifyContentLink, SpotifyContentLinkType } from '~/@types/global';
+
 import { SpotifyMetadata } from '~/server/services/spotify';
 import { getQueryFromMetadata } from '~/utils/query';
 
 import * as ENV from '~/config/env/server';
+import { getCheerioDoc, metaTagContent } from '~/utils/metaContent';
 
 const {
   apiSearchUrl,
@@ -22,9 +27,9 @@ interface YoutubeSearchListResponse {
 
 export const getYoutubeLink = async (metadata: SpotifyMetadata) => {
   const query = getQueryFromMetadata(metadata);
-  const url = `${apiSearchUrl}?q=${query}&maxResults=1&key=${apiKey}`;
+  const url = `${apiSearchUrl}?q=${encodeURIComponent(query)}&maxResults=1&key=${apiKey}`;
 
-  const response: YoutubeSearchListResponse = await fetch(url).then((res) => res.json());
+  const response = (await fetch(url).then((res) => res.json()) as YoutubeSearchListResponse);
 
   if (response.error) {
     throw new Error(response.error.message);
@@ -32,13 +37,28 @@ export const getYoutubeLink = async (metadata: SpotifyMetadata) => {
 
   const { videoId, channelId, playlistId } = response.items[0].id;
 
+  let youtubeLink = '';
+
+  if (videoId) {
+    youtubeLink = `${baseUrl}/watch?v=${videoId}`;
+  }
+
   if (channelId) {
-    return `${baseUrl}/channel/${channelId}`;
+    youtubeLink = `${baseUrl}/channel/${channelId}`;
   }
 
   if (playlistId) {
-    return `${baseUrl}/playlist?list=${playlistId}`;
+    youtubeLink = `${baseUrl}/playlist?list=${playlistId}`;
   }
 
-  return `${baseUrl}/watch?v=${videoId}`;
+  const html = await fetch(youtubeLink).then((res) => res.text());
+  const doc = getCheerioDoc(html);
+
+  const youtubeVideoTitle = metaTagContent(doc, 'og:title', 'property') ?? '';
+
+  if (compareTwoStrings(youtubeVideoTitle, query) < 0.4) {
+    return undefined;
+  }
+
+  return { type: SpotifyContentLinkType.Youtube, url: youtubeLink } as SpotifyContentLink;
 };

--- a/src/utils/metaContent.ts
+++ b/src/utils/metaContent.ts
@@ -1,0 +1,9 @@
+import * as cheerio from 'cheerio';
+
+export function getCheerioDoc(html: string) {
+  return cheerio.load(html);
+}
+
+export function metaTagContent(doc: cheerio.CheerioAPI, type: string, attr: string) {
+  return doc(`meta[${attr}='${type}']`).attr('content');
+}

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -26,5 +26,5 @@ export const getQueryFromMetadata = ({ title, description, type }: SpotifyMetada
     query = artist ? `${query} ${artist}` : query;
   }
 
-  return encodeURIComponent(query);
+  return query;
 };

--- a/tests/landing.spec.ts
+++ b/tests/landing.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Landing Page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('http://localhost:3000');
+    await page.goto('/');
   });
 
   test('should has title', async ({ page }) => {

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -21,6 +21,29 @@ test.describe('Search Tests', () => {
     expect(searchCardText).toContain('Listen on Apple Music');
     expect(searchCardText).toContain('Listen on Tidal');
     expect(searchCardText).toContain('Listen on SoundCloud');
+
+    const youtubeLink = await page.getByText('Listen on Youtube').getAttribute('href');
+    const appleMusicLink = await page.getByText('Listen on Apple Music').getAttribute('href');
+    const tidalLink = await page.getByText('Listen on Tidal').getAttribute('href');
+    const soundcloudLink = await page.getByText('Listen on SoundCloud').getAttribute('href');
+
+    expect(youtubeLink).toBe('https://www.youtube.com/watch?v=zhY_0DoQCQs');
+    expect(appleMusicLink).toBe('https://music.apple.com/search?term=Do%20Not%20Disturb%20Drake');
+    expect(tidalLink).toBe('https://listen.tidal.com/search?q=Do%20Not%20Disturb%20Drake');
+    expect(soundcloudLink).toBe('https://soundcloud.com/search/sounds?q=Do%20Not%20Disturb%20Drake');
+  });
+
+  test('should return "No links found" with a valid spotifyLink - Spotify exclusive content', async ({ page }) => {
+    const searchCard = page.getByTestId('search-card');
+
+    const exclusiveContentSpotifyLink = 'https://open.spotify.com/episode/5dNTXSZtkQLm6HuVdboFtx';
+
+    await page.fill('#song-link', exclusiveContentSpotifyLink);
+    await page.press('#song-link', 'Enter');
+
+    const searchCardText = await searchCard.textContent() ?? '';
+
+    expect(searchCardText).toContain('No Links found');
   });
 
   test('should return an error with an invalid spotifyLink', async ({ page }) => {

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -4,7 +4,7 @@ test.describe('Search Tests', () => {
   const spotifyLink = 'https://open.spotify.com/track/2KvHC9z14GSl4YpkNMX384';
 
   test.beforeEach(async ({ page }) => {
-    await page.goto('http://localhost:3000');
+    await page.goto('/');
   });
 
   test('should return a song with a valid spotifyLink', async ({ page }) => {
@@ -43,7 +43,11 @@ test.describe('Search Tests', () => {
 
     const searchCardText = await searchCard.textContent() ?? '';
 
-    expect(searchCardText).toContain('No Links found');
+    expect(searchCardText).toContain('No links found');
+    expect(searchCardText).not.toContain('Listen on Youtube');
+    expect(searchCardText).not.toContain('Listen on Apple Music');
+    expect(searchCardText).not.toContain('Listen on Tidal');
+    expect(searchCardText).not.toContain('Listen on SoundCloud');
   });
 
   test('should return an error with an invalid spotifyLink', async ({ page }) => {
@@ -60,6 +64,7 @@ test.describe('Search Tests', () => {
   test('should increment the queries performed counter', async ({ page }) => {
     const searchCount = page.getByTestId('search-count');
 
+    await page.waitForTimeout(1000);
     const previousSearchCount = Number(await searchCount.textContent());
 
     await page.fill('#song-link', spotifyLink);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1358,6 +1358,11 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
 
+"@types/string-similarity@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/string-similarity/-/string-similarity-4.0.0.tgz#8cc03d5d1baad2b74530fe6c7d849d5768d391ad"
+  integrity sha512-dMS4S07fbtY1AILG/RhuwmptmzK1Ql8scmAebOTJ/8iBtK/KI17NwGwKzu1uipjj8Kk+3mfPxum56kKZE93mzQ==
+
 "@typescript-eslint/eslint-plugin@^5.56.0":
   version "5.57.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.1.tgz#d1ab162a3cd2671b8a1c9ddf6e2db73b14439735"
@@ -3844,6 +3849,11 @@ streamsearch@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
+string-similarity@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.4.tgz#42d01ab0b34660ea8a018da8f56a3309bb8b2a5b"
+  integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
 
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"


### PR DESCRIPTION
Show "No links found" for Spotify exclusive content.
Refactored `SpotifyContent` interface, replaced link object with an array to improve readability.

Added minimal version checking to `GET api/search` endpoint. If `v=2` is sent, it will return the new `SpotifyContent` link structure, otherwise it will keep the old one (backwards compatibility for Raycast extension).

Regression test added should return "No links found" with a valid spotifyLink - Spotify exclusive content"