### PR TITLE
feat: support shortened soundcloud links

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -15,7 +15,7 @@ export const DEEZER_LINK_REGEX =
   /^https:\/\/www\.deezer\.com\/(?:[a-z]{2}\/)?(?:track|album|playlist|artist|episode|show)\/(\d+)/;
 
 export const SOUNDCLOUD_LINK_REGEX =
-  /^https:\/\/soundcloud\.com\/([\w-]+)\/([\w-]+)(?:\/sets\/([\w-]+))?(?:[\?#].*)?/;
+  /^(?:https:\/\/soundcloud\.com\/([\w-]+)\/([\w-]+)(?:\/sets\/([\w-]+))?(?:[\?#].*)?|https:\/\/on\.soundcloud\.com\/([\w-]{8,}))$/;
 
 export const TIDAL_LINK_REGEX =
   /^https:\/\/tidal\.com\/browse\/(track|artist|album|mix|video)\/([\w-]+)(?:\/[\w-]+)?(?:[\?#].*)?$/;

--- a/src/parsers/link.ts
+++ b/src/parsers/link.ts
@@ -62,7 +62,7 @@ export const getSearchParser = (link?: string, searchId?: string) => {
   }
 
   const soundCloudMatch = source.match(SOUNDCLOUD_LINK_REGEX);
-  const soundCloudId = soundCloudMatch ? soundCloudMatch[3] || soundCloudMatch[2] : null;
+  const soundCloudId = soundCloudMatch ? soundCloudMatch[3] || soundCloudMatch[2] || soundCloudMatch[4] : null;
   if (soundCloudId) {
     id = soundCloudId;
     type = Parser.SoundCloud;


### PR DESCRIPTION
adds support for on.soundcloud.com, which is the default share link used by the mobile app