### PR TITLE
fix(spotify): use /embed __NEXT_DATA__ instead of OG meta tags

### DIFF
--- a/src/parsers/spotify.ts
+++ b/src/parsers/spotify.ts
@@ -1,14 +1,29 @@
+// PATCHED VERSION OF UPSTREAM src/parsers/spotify.ts
+//
+// As of 2026, open.spotify.com no longer ships server-side OG meta
+// tags for resource pages — only `og:site_name` is present, the rest
+// are rendered client-side by the SPA. So scraping `og:title` /
+// `og:description` / `og:image` from the resource page returns null
+// and every Spotify-as-source request 500s with "Spotify metadata
+// not found".
+//
+// This patch replaces the OG-tag scrape with a fetch of
+// /embed/<type>/<id>, which still server-renders a Next.js
+// __NEXT_DATA__ JSON blob containing all the metadata we need
+// (name, artists, release date, image, audio preview).
+//
+// Applied at build time by scripts/build-backend.sh so the upstream
+// submodule stays clean. When the upstream maintainer ships a fix
+// for this, drop this file + the cp step from the build script.
 import {
   SPOTIFY_LINK_DESKTOP_REGEX,
   SPOTIFY_LINK_MOBILE_REGEX,
 } from '~/config/constants';
 import { MetadataType, Parser } from '~/config/enum';
 import { cacheSearchMetadata, getCachedSearchMetadata } from '~/services/cache';
-import { fetchMetadata } from '~/services/metadata';
 import { type SearchMetadata } from '~/services/search';
 import HttpClient from '~/utils/http-client';
 import { logger } from '~/utils/logger';
-import { getCheerioDoc, metaTagContent } from '~/utils/scraper';
 
 enum SpotifyMetadataType {
   Song = 'music.song',
@@ -28,6 +43,61 @@ const SPOTIFY_METADATA_TO_METADATA_TYPE = {
   [SpotifyMetadataType.Show]: MetadataType.Show,
 };
 
+const NEXT_DATA_REGEX = /<script id="__NEXT_DATA__"[^>]*>(.+?)<\/script>/s;
+
+const SPOTIFY_TYPE_TO_METADATA: Record<string, SpotifyMetadataType> = {
+  track: SpotifyMetadataType.Song,
+  album: SpotifyMetadataType.Album,
+  artist: SpotifyMetadataType.Artist,
+  playlist: SpotifyMetadataType.Playlist,
+  episode: SpotifyMetadataType.Podcast,
+  show: SpotifyMetadataType.Show,
+};
+
+interface SpotifyEntity {
+  name?: string;
+  title?: string;
+  subtitle?: string;
+  artists?: Array<{ name?: string }>;
+  releaseDate?: { isoString?: string };
+  visualIdentity?: { image?: Array<{ url?: string; maxWidth?: number }> };
+  coverArt?: { sources?: Array<{ url?: string }> };
+  audioPreview?: { url?: string };
+  type?: string;
+  uri?: string;
+}
+
+function parseSpotifyResourceFromLink(
+  link: string
+): { type: string; id: string } | null {
+  const m = link.match(
+    /open\.spotify\.com\/(track|album|artist|playlist|episode|show)\/([A-Za-z0-9]+)/
+  );
+  if (!m) return null;
+  return { type: m[1], id: m[2] };
+}
+
+// __NEXT_DATA__ nests the entity under pageProps somewhere; walk
+// (bounded) for the first object with our expected shape. We use
+// (name + uri + type) as the entity signature — works for tracks,
+// albums, artists, playlists, episodes, and shows.
+function findEntity(o: unknown, depth = 0): SpotifyEntity | null {
+  if (depth > 8 || o === null || typeof o !== 'object') return null;
+  const obj = o as Record<string, unknown>;
+  if (
+    typeof obj.name === 'string' &&
+    typeof obj.uri === 'string' &&
+    typeof obj.type === 'string'
+  ) {
+    return obj as SpotifyEntity;
+  }
+  for (const v of Object.values(obj)) {
+    const r = findEntity(v, depth + 1);
+    if (r) return r;
+  }
+  return null;
+}
+
 export const getSpotifyMetadata = async (id: string, link: string) => {
   const cached = await getCachedSearchMetadata(id, Parser.Spotify);
   if (cached) {
@@ -36,37 +106,68 @@ export const getSpotifyMetadata = async (id: string, link: string) => {
   }
 
   try {
-    let html = await fetchMetadata(link);
-
-    if (SPOTIFY_LINK_MOBILE_REGEX.test(link)) {
-      link = html.match(SPOTIFY_LINK_DESKTOP_REGEX)?.[0] ?? '';
-
-      if (!link) {
-        throw new Error('Invalid mobile spotify link');
-      }
-
-      // wait a random amount of time to avoid rate limiting
-      await new Promise(res => setTimeout(res, Math.random() * 1000));
-
-      logger.info(`[${getSpotifyMetadata.name}] parse metadata (desktop): ${link}`);
-
-      html = await HttpClient.get<string>(link, {
-        retries: 2,
-      });
+    let resolvedLink = link;
+    if (SPOTIFY_LINK_MOBILE_REGEX.test(resolvedLink)) {
+      const html = await HttpClient.get<string>(resolvedLink, { retries: 2 });
+      resolvedLink = html.match(SPOTIFY_LINK_DESKTOP_REGEX)?.[0] ?? '';
+      if (!resolvedLink) throw new Error('Invalid mobile spotify link');
+      logger.info(
+        `[${getSpotifyMetadata.name}] resolved mobile -> ${resolvedLink}`
+      );
     }
 
-    const doc = getCheerioDoc(html);
+    const resource = parseSpotifyResourceFromLink(resolvedLink);
+    if (!resource) throw new Error('Unrecognised Spotify URL');
 
-    const title = metaTagContent(doc, 'og:title', 'property')?.trim();
-    const description = metaTagContent(doc, 'og:description', 'property');
-    const image = metaTagContent(doc, 'og:image', 'property');
-    const audio = metaTagContent(doc, 'og:audio', 'property');
+    const embedURL = `https://open.spotify.com/embed/${resource.type}/${resource.id}`;
+    logger.info(`[${getSpotifyMetadata.name}] fetching embed: ${embedURL}`);
+    const html = await HttpClient.get<string>(embedURL, { retries: 2 });
 
-    const type = link.includes('episode')
-      ? SpotifyMetadataType.Podcast
-      : (metaTagContent(doc, 'og:type', 'property') as SpotifyMetadataType);
+    const nextDataMatch = html.match(NEXT_DATA_REGEX);
+    if (!nextDataMatch) {
+      throw new Error('Spotify embed page missing __NEXT_DATA__');
+    }
 
-    if (!title || !description || !type || !image) {
+    const nextData = JSON.parse(nextDataMatch[1]);
+    const entity = findEntity(nextData);
+    if (!entity) throw new Error('Spotify metadata not found');
+
+    const title = (entity.name ?? entity.title ?? '').trim();
+    // Tracks have an `artists[]` array; albums/artists/etc. expose
+    // the artist as `subtitle` instead.
+    const artists = Array.isArray(entity.artists) && entity.artists.length > 0
+      ? entity.artists.map(a => a.name).filter(Boolean).join(', ')
+      : (entity.subtitle ?? '');
+    const year = entity.releaseDate?.isoString
+      ? new Date(entity.releaseDate.isoString).getUTCFullYear().toString()
+      : '';
+
+    // Match the legacy `og:description` shape "Artist · Type · Year"
+    // so getSpotifyQueryFromMetadata's `^([^·]+)\s+·` regex still works.
+    const typeWord =
+      resource.type === 'track'
+        ? 'Song'
+        : resource.type === 'episode'
+          ? 'Episode'
+          : resource.type.charAt(0).toUpperCase() + resource.type.slice(1);
+    const descriptionParts = [artists, typeWord];
+    if (year) descriptionParts.push(year);
+    const description = descriptionParts.filter(Boolean).join(' · ');
+
+    const images = Array.isArray(entity.visualIdentity?.image)
+      ? entity.visualIdentity!.image!
+      : [];
+    const largest = images.reduce<{ url?: string; maxWidth?: number } | null>(
+      (best, img) =>
+        !best || (img.maxWidth ?? 0) > (best.maxWidth ?? 0) ? img : best,
+      null
+    );
+    const image = largest?.url ?? entity.coverArt?.sources?.[0]?.url;
+
+    const audio = entity.audioPreview?.url ?? undefined;
+
+    const spotifyType = SPOTIFY_TYPE_TO_METADATA[resource.type];
+    if (!title || !image || !spotifyType) {
       throw new Error('Spotify metadata not found');
     }
 
@@ -74,7 +175,7 @@ export const getSpotifyMetadata = async (id: string, link: string) => {
       id,
       title,
       description,
-      type: SPOTIFY_METADATA_TO_METADATA_TYPE[type],
+      type: SPOTIFY_METADATA_TO_METADATA_TYPE[spotifyType],
       image,
       audio,
     } as SearchMetadata;
@@ -89,23 +190,19 @@ export const getSpotifyMetadata = async (id: string, link: string) => {
 
 export const getSpotifyQueryFromMetadata = (metadata: SearchMetadata) => {
   const parsedTitle = metadata.title
-    // Remove suffixes/tags added to the title by Spotify
     .replace(
       /(\s(?:–|-)\s.*?\s(?:by|von|de|par|di|door|av|af|przez)\s.+)?\s\|\sSpotify$/i,
       ''
     )
-    // Remove emojis
     .replace(
       /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{1F900}-\u{1F9FF}\u{1F1E0}-\u{1F1FF}·]/gu,
       ''
     )
-    // Clean extra whitespace
     .replace(/\s+/g, ' ')
     .trim();
 
   let artist = '';
 
-  // Extract the artist from the description based on the metadata type
   if (metadata.type === MetadataType.Song || metadata.type === MetadataType.Album) {
     [, artist] = metadata.description.match(/^([^·]+)\s+·/) ?? [];
   } else if (metadata.type === MetadataType.Podcast) {

--- a/tests/api.integration.test.ts
+++ b/tests/api.integration.test.ts
@@ -79,7 +79,7 @@ describe('Api router', () => {
         .onGet(getSoundCloudSearchLink(query))
         .reply(200, searchSnapshots.soundCloudRollingStone);
       httpMock
-        .onGet('https://open.spotify.com/track/3AhXZa8sUQht0UEdBJgpGc')
+        .onGet('https://open.spotify.com/embed/track/3AhXZa8sUQht0UEdBJgpGc')
         .reply(200, headSnapshots.spotifyTrackRollingStone);
 
       const response = await nodeFetch(searchEndpointUrl, {
@@ -140,7 +140,7 @@ describe('Api router', () => {
       httpMock.onGet(getSoundCloudSearchLink(query)).reply(500);
       // Mock Spotify metadata API
       httpMock
-        .onGet('https://open.spotify.com/track/3AhXZa8sUQht0UEdBJgpGc')
+        .onGet('https://open.spotify.com/embed/track/3AhXZa8sUQht0UEdBJgpGc')
         .reply(200, headSnapshots.spotifyTrackRollingStone);
 
       httpMock.onGet(/openapi\.tidal\.com.*searchresults/).reply(404);
@@ -176,7 +176,7 @@ describe('Api router', () => {
 
     it('should return 200 when adapter adapter matches the parser type', async () => {
       httpMock
-        .onGet('https://open.spotify.com/track/3AhXZa8sUQht0UEdBJgpGc')
+        .onGet('https://open.spotify.com/embed/track/3AhXZa8sUQht0UEdBJgpGc')
         .reply(200, headSnapshots.spotifyTrackRollingStone);
 
       const response = await nodeFetch(searchEndpointUrl, {

--- a/tests/mocks/snapshots.ts
+++ b/tests/mocks/snapshots.ts
@@ -13,28 +13,28 @@ export type SnapshotTarget = {
 
 export const headSnapshotTargets = {
   spotifyTrackRollingStone: {
-    url: 'https://open.spotify.com/track/3AhXZa8sUQht0UEdBJgpGc',
-    file: 'tests/mocks/head/spotify-track-3AhXZa8sUQht0UEdBJgpGc.html',
+    url: 'https://open.spotify.com/embed/track/3AhXZa8sUQht0UEdBJgpGc',
+    file: 'tests/mocks/head/spotify-embed-track-3AhXZa8sUQht0UEdBJgpGc.html',
   },
   spotifyAlbumStories: {
-    url: 'https://open.spotify.com/album/7dqftJ3kas6D0VAdmt3k3V',
-    file: 'tests/mocks/head/spotify-album-7dqftJ3kas6D0VAdmt3k3V.html',
+    url: 'https://open.spotify.com/embed/album/7dqftJ3kas6D0VAdmt3k3V',
+    file: 'tests/mocks/head/spotify-embed-album-7dqftJ3kas6D0VAdmt3k3V.html',
   },
   spotifyArtistJCole: {
-    url: 'https://open.spotify.com/artist/6l3HvQ5sa6mXTsMTB19rO5',
-    file: 'tests/mocks/head/spotify-artist-6l3HvQ5sa6mXTsMTB19rO5.html',
+    url: 'https://open.spotify.com/embed/artist/6l3HvQ5sa6mXTsMTB19rO5',
+    file: 'tests/mocks/head/spotify-embed-artist-6l3HvQ5sa6mXTsMTB19rO5.html',
   },
   spotifyPlaylistBadBunny: {
-    url: 'https://open.spotify.com/playlist/37i9dQZF1DX2apWzyECwyZ',
-    file: 'tests/mocks/head/spotify-playlist-37i9dQZF1DX2apWzyECwyZ.html',
+    url: 'https://open.spotify.com/embed/playlist/37i9dQZF1DX2apWzyECwyZ',
+    file: 'tests/mocks/head/spotify-embed-playlist-37i9dQZF1DX2apWzyECwyZ.html',
   },
   spotifyEpisodeTerceraVuelta: {
-    url: 'https://open.spotify.com/episode/2uvOfpJRRliCWpbiCXKf4Q',
-    file: 'tests/mocks/head/spotify-episode-2uvOfpJRRliCWpbiCXKf4Q.html',
+    url: 'https://open.spotify.com/embed/episode/2uvOfpJRRliCWpbiCXKf4Q',
+    file: 'tests/mocks/head/spotify-embed-episode-2uvOfpJRRliCWpbiCXKf4Q.html',
   },
   spotifyEpisodeWaveform: {
-    url: 'https://open.spotify.com/episode/43TCrgmP23qkLcAXZQN8qT',
-    file: 'tests/mocks/head/spotify-episode-43TCrgmP23qkLcAXZQN8qT.html',
+    url: 'https://open.spotify.com/embed/episode/43TCrgmP23qkLcAXZQN8qT',
+    file: 'tests/mocks/head/spotify-embed-episode-43TCrgmP23qkLcAXZQN8qT.html',
   },
 } as const satisfies Record<string, SnapshotTarget>;
 

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -66,7 +66,7 @@ describe('GET /search', () => {
 
       // Mock Spotify metadata API
       httpMock
-        .onGet('https://open.spotify.com/track/3AhXZa8sUQht0UEdBJgpGc')
+        .onGet('https://open.spotify.com/embed/track/3AhXZa8sUQht0UEdBJgpGc')
         .reply(200, headSnapshots.spotifyTrackRollingStone);
 
       // Mock adapter API calls
@@ -178,7 +178,7 @@ describe('GET /search', () => {
 
       // Mock Spotify metadata API
       httpMock
-        .onGet(/open\.spotify\.com\/track\/3AhXZa8sUQht0UEdBJgpGc/)
+        .onGet(/open\.spotify\.com\/embed\/track\/3AhXZa8sUQht0UEdBJgpGc/)
         .reply(200, headSnapshots.spotifyTrackRollingStone);
 
       // Mock adapter API calls
@@ -290,7 +290,7 @@ describe('GET /search', () => {
 
       // Mock Spotify metadata API
       httpMock
-        .onGet(/open\.spotify\.com\/track\/3AhXZa8sUQht0UEdBJgpGc/)
+        .onGet(/open\.spotify\.com\/embed\/track\/3AhXZa8sUQht0UEdBJgpGc/)
         .reply(200, headSnapshots.spotifyTrackRollingStone);
 
       // Mock adapter API calls
@@ -403,7 +403,7 @@ describe('GET /search', () => {
     it('should return 200', async () => {
       // Mock Spotify metadata API
       httpMock
-        .onGet(/open\.spotify\.com\/album\/7dqftJ3kas6D0VAdmt3k3V/)
+        .onGet(/open\.spotify\.com\/embed\/album\/7dqftJ3kas6D0VAdmt3k3V/)
         .reply(200, headSnapshots.spotifyAlbumStories);
 
       // Mock adapter API calls
@@ -514,7 +514,7 @@ describe('GET /search', () => {
 
       // Mock Spotify metadata API
       httpMock
-        .onGet('https://open.spotify.com/artist/6l3HvQ5sa6mXTsMTB19rO5')
+        .onGet('https://open.spotify.com/embed/artist/6l3HvQ5sa6mXTsMTB19rO5')
         .reply(200, headSnapshots.spotifyArtistJCole);
 
       // Mock adapter API calls
@@ -621,7 +621,7 @@ describe('GET /search', () => {
 
       // Mock Spotify metadata API
       httpMock
-        .onGet('https://open.spotify.com/playlist/37i9dQZF1DX2apWzyECwyZ')
+        .onGet('https://open.spotify.com/embed/playlist/37i9dQZF1DX2apWzyECwyZ')
         .reply(200, headSnapshots.spotifyPlaylistBadBunny);
 
       // Mock adapter API calls
@@ -693,7 +693,7 @@ describe('GET /search', () => {
 
       // Mock Spotify metadata API
       httpMock
-        .onGet(/open\.spotify\.com\/episode\/2uvOfpJRRliCWpbiCXKf4Q/)
+        .onGet(/open\.spotify\.com\/embed\/episode\/2uvOfpJRRliCWpbiCXKf4Q/)
         .reply(200, headSnapshots.spotifyEpisodeTerceraVuelta);
 
       // Mock adapter API calls - podcasts usually don't have matches on other platforms
@@ -744,7 +744,7 @@ describe('GET /search', () => {
 
       // Mock Spotify metadata API
       httpMock
-        .onGet('https://open.spotify.com/episode/43TCrgmP23qkLcAXZQN8qT')
+        .onGet('https://open.spotify.com/embed/episode/43TCrgmP23qkLcAXZQN8qT')
         .reply(200, headSnapshots.spotifyEpisodeWaveform);
 
       // Mock adapter API calls


### PR DESCRIPTION
## Problem

`open.spotify.com/{type}/{id}` pages no longer render server-side OG meta tags for the resource — only `og:site_name` is present, the rest are populated client-side by the SPA. The parser checks `if (!title || !description || !type || !image)` and throws **"Spotify metadata not found"**, so every Spotify-as-source request 500s. Verified by curling the page directly (only `og:site_name` present in the HTML).

## Fix

The `/embed/{type}/{id}` page still server-renders a Next.js `__NEXT_DATA__` JSON blob with everything we need:

- `name` → title
- `artists[]` / `subtitle` → artist text (albums use `subtitle`)
- `releaseDate.isoString` → year
- `visualIdentity.image[]` → cover art (multiple sizes; we pick the largest)
- `audioPreview.url` → preview clip
- `type` → `track | album | artist | playlist | episode | show`

This PR replaces the OG-tag scrape in `getSpotifyMetadata` with `__NEXT_DATA__` extraction. The legacy `getSpotifyQueryFromMetadata` regexes are untouched because we format `description` as `"Artist · Type · Year"` to match the old `og:description` shape — so `^([^·]+)\s+·` still extracts the artist correctly.

## Verification

End-to-end against three Spotify URL types (using a local backend with no Tidal/YouTube keys):

| URL | Result |
|---|---|
| `https://open.spotify.com/track/4cOdK2wGLETKBW3PvgPWqT` | "Never Gonna Give You Up" by Rick Astley → Apple Music + Deezer + SoundCloud links returned |
| `https://open.spotify.com/album/4LH4d3cOWNNsVw41Gqt2kv` | "The Dark Side of the Moon" by Pink Floyd → same |
| `https://open.spotify.com/artist/0gxyHStUsqpMadRV0Di1Qt` | Rick Astley → same |

## Tests

- `tests/mocks/snapshots.ts` — snapshot URLs now point at `/embed/{type}/{id}`. `bun run scripts/fetch-snapshots.ts` regenerates the HTML fixtures cleanly.
- `tests/search.test.ts` + `tests/api.integration.test.ts` — `httpMock.onGet` setups updated to intercept the embed URLs the parser now fetches.
- `tests/parsers/spotify-parser.test.ts` — untouched. It only exercises `getSpotifyQueryFromMetadata`, which still works on the new description format.

**Heads up:** 8 of the 75 integration tests still fail after this change. The patterns are:
- `expect.stringMatching(/.../)` and `expect.any(String)` matchers in expected objects don't appear to behave under `bun:test` the way they do under Jest — they show up as literal `StringMatching /…/` and `Any<String>` strings in the diff output even when the received value matches.
- One of the Pandora URL fixtures now returns a different track-id from upstream (`TR9Pc9g74Z7KhxX` → `TRxd7mxKzqvVd7m`), unrelated to the parser change.

Both look like fixture-refresh / matcher-API issues independent of this fix — happy to follow up with whatever shape you'd prefer (e.g. switch to literal expected values + re-run `fetch-snapshots`, or refactor expected blocks).

## Why this matters

Right now `idonthavespotify.sjdonado.com` and any self-hosted instance returns 500 for any Spotify URL. The fix is upstream-side: every existing user benefits without needing to redeploy.

I'm shipping the same patch in a downstream Mac wrapper of this service ([idonthavespotify-mac](https://github.com/timmyo2l/idonthavespotify-mac), still private — happy to share if useful) — wanted to send the change here too so we can drop the local patch eventually.